### PR TITLE
Auto run on fpga

### DIFF
--- a/compiler_set/Makefile
+++ b/compiler_set/Makefile
@@ -145,6 +145,14 @@ test-simple: $(TESTS:%=test/%.run_f)
 test-comp: $(MEMOIZE_TESTS:%=test/%.run_cmp)
 test-large: $(LARGE_TESTS:%=test/%.run_large)
 
+test-core: $(TESTS:%=test/%.run_core) $(MEMOIZE_TESTS:%=test/%.run_core_cmp) $(LARGE_TESTS:%=test/%.run_core_cmp)
+
+%.run_core: %.sim %.core
+	diff $*.sim $*.core
+
+%.run_core_cmp: %.core
+	diff $*.ans $*.core
+
 # .bin, .sが存在しないときのみビルドして実行
 %.run:
 	make $*.bin
@@ -162,21 +170,27 @@ test-large: $(LARGE_TESTS:%=test/%.run_large)
 	simulator/simulator $*.bin | tee /tmp/`basename $*`.out && \
 		diff /tmp/`basename $*`.out $*.ans
 
-%.ans:
-	make $*.bin_f
-	simulator/simulator $*.bin 2>/dev/null | tee $*.ans
-	ocaml $*.ml
-
 %.run_large:
 	make $*.bin_f
 	simulator/simulator $*.bin > /tmp/`basename $*`.out && \
 		diff /tmp/`basename $*`.out $*.ans
 
+%.core: %.bin
+	../core_runner/run_fpga $*.bin > $*.core
+
+%.ocaml: %.ml
+	ocaml $*.ml > $*.ocaml
+
+%.sim: %.bin
+	simulator/simulator $*.bin > $*.sim
+
+%.ans:
+	make $*.bin_f
+	simulator/simulator $*.bin 2>/dev/null | tee $*.ans
+	ocaml $*.ml
+
 # .bin, .sが存在しないときのみビルド
-%.bin:
-	cat $(LIB_ML) $*.ml > __tmp__.ml
-	$(MIN_CAML) $(OPTION) $(BINARY) $(INLINE) __tmp__
-	cd linker; $(LINKER) ../$(LIB_ASM) ../__tmp__.s ${abspath $*.s}
+%.bin: %.s
 	assembler/assembler $*.s $*.bin
 
 # .bin, .sが存在しててもビルドする
@@ -187,7 +201,7 @@ test-large: $(LARGE_TESTS:%=test/%.run_large)
 	assembler/assembler $*.s $*.bin
 
 # .sが存在しないときのみビルド
-%.s:
+%.s: %.ml
 	cat $(LIB_ML) $*.ml > __tmp__.ml
 	$(MIN_CAML) $(OPTION) $(BINARY) $(INLINE) __tmp__
 	cd linker; $(LINKER) ../$(LIB_ASM) ../__tmp__.s ${abspath $*.s}

--- a/compiler_set/compiler/emit.ml
+++ b/compiler_set/compiler/emit.ml
@@ -324,5 +324,12 @@ let f (Prog(fundefs, e)) =
   stackset := S.empty;
   stackmap := [];
   g (NonTail(reg_0), e);
+  Out.print buf (Out.Comment "Send end marker, then halt");
+  Out.print buf (Out.AddI("$r3", reg_0, 231));
+  Out.print buf (Out.Outputb("$r3"));
+  Out.print buf (Out.AddI("$r3", reg_0, 181));
+  Out.print buf (Out.Outputb("$r3"));
+  Out.print buf (Out.AddI("$r3", reg_0, 130));
+  Out.print buf (Out.Outputb("$r3"));
   Out.print buf Out.Halt;
   List.rev !buf

--- a/compiler_set/simulator/simulator.cpp
+++ b/compiler_set/simulator/simulator.cpp
@@ -618,7 +618,8 @@ int simulate(simulation_options * opt)
 				D_REGISTER(log_fp, "REG: INPUTB %02X %08X\n", get_rt(inst), IRT);
 				break;
 			case OUTPUTB:
-				if (opt->enable_stdout) {
+				if (opt->enable_stdout &&
+				    IRT != 231 && IRT != 181 && IRT != 130) { // 終了マーカは無視。ログには出す
 					printf("%c", (char)IRT);
 				}
 				D_IO(log_fp, "IO: %c\n", (char)IRT);

--- a/core_runner/run_fpga
+++ b/core_runner/run_fpga
@@ -7,6 +7,6 @@ IMPACT=$HOME/Xilinx/ISE_DS/ISE/bin/lin64/impact
 source $HOME/Xilinx/ISE_DS/settings64.sh >/dev/null 2>/dev/null
 export XILINXD_LICENSE_FILE=2100@133.11.27.150
 $IMPACT -batch mimic.impact.cmd > /dev/null 2>/dev/null
-\cd -
+\cd - > /dev/null
 cut -f1 $1 > $tmpfile
 $HOME/programs/cpu/io_program/readwrite -d $tmpfile

--- a/core_runner/run_fpga
+++ b/core_runner/run_fpga
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+tmpfile=/tmp/`basename $1`
+
+cd $HOME/hwex/tools
+. use-ise.sh >/dev/null
+impact -batch  mimic.impact.cmd > /dev/null
+cd -
+cut -f1 $1 > $tmpfile
+$HOME/programs/cpu/io_program/readwrite -d $tmpfile

--- a/core_runner/run_fpga
+++ b/core_runner/run_fpga
@@ -1,10 +1,12 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 tmpfile=/tmp/`basename $1`
+IMPACT=$HOME/Xilinx/ISE_DS/ISE/bin/lin64/impact
 
-cd $HOME/hwex/tools
-. use-ise.sh >/dev/null
-impact -batch  mimic.impact.cmd > /dev/null
-cd -
+\cd $HOME/hwex/tools
+source $HOME/Xilinx/ISE_DS/settings64.sh >/dev/null 2>/dev/null
+export XILINXD_LICENSE_FILE=2100@133.11.27.150
+$IMPACT -batch mimic.impact.cmd > /dev/null 2>/dev/null
+\cd -
 cut -f1 $1 > $tmpfile
 $HOME/programs/cpu/io_program/readwrite -d $tmpfile


### PR DESCRIPTION
FPGA 上でのテストを自動化しました。
パイプライン実装にむけての足固めと、今後シミュレータでは動作するが実機で動作しないようなケースが出てきた時に対応しやすくためです。

あらかじめ入力が決めらていない場合はいつプログラムが終了するか分からないため、
終了コードを発行するコードを追加しました。「終」 を UTF-8 表現した3バイトを出力します。

デバッグなどで戸惑う可能性がありますので、皆さん確認おねがいします。とくに @u-natsuki さん。

どなたか内容をチェックしたらマージボタンを押しちゃってください。
