### PR TITLE
プレゼンテーションソフトをシミュレータで動作

### DIFF
--- a/compiler_set/Makefile
+++ b/compiler_set/Makefile
@@ -77,3 +77,8 @@ lor-clean:
 	cat $(LIB_ML) $*.ml > __tmp__.ml
 	$(MIN_CAML) $(OPTION) $(BINARY) $(INLINE) __tmp__
 	cd linker; $(LINKER) ../$(LIB_ASM) ../__tmp__.s ${abspath $*.s}
+
+%.s: %.ml
+	cat $(LIB_ML) $*.ml > __tmp__.ml
+	$(MIN_CAML) $(OPTION) $(BINARY) $(INLINE) __tmp__
+	cd linker; $(LINKER) ../$(LIB_ASM) ../__tmp__.s ${abspath $*.s}

--- a/compiler_set/assembler/assembler.h
+++ b/compiler_set/assembler/assembler.h
@@ -70,6 +70,7 @@ PROTO_R(_inputb);
 PROTO_R(_outputb);
 PROTO_R(_halt);
 PROTO_I(_debug);
+PROTO_R(_display);
 
 
 // 0オペランド命令の読み込みフォーマット

--- a/compiler_set/assembler/encode.cpp
+++ b/compiler_set/assembler/encode.cpp
@@ -44,6 +44,7 @@ DEFINE_R(_inputb, INPUTB, 0, 0);
 DEFINE_R(_outputb, OUTPUTB, 0, 0);
 DEFINE_R(_halt, HALT, 0, 0);
 DEFINE_I(_debug, DEBUG);
+DEFINE_R(_display, DISPLAY, 0, 0);
 
 typedef union
 {
@@ -446,6 +447,15 @@ bool encode(char* instName, char* buffer, map<uint32_t, string>& labelNames, uin
 	  if (n == 2)
 	    {
 	      code = _debug(rs, rt, imm);
+	      return true;
+	    }
+	}
+	if (eq(instName, "display"))
+	{
+	  int n = sscanf(buffer, formRR, dummy, &rs, &rt);
+	  if (n == 3)
+	    {
+	      code = _display(rs, rt, rd);
 	      return true;
 	    }
 	}

--- a/compiler_set/include/common.h
+++ b/compiler_set/include/common.h
@@ -68,5 +68,7 @@
 #define HALT    (0b111111)
 #define DEBUG   (0b101111)
 
+#define DISPLAY (0b001000)
+
 using namespace std;
 #endif

--- a/compiler_set/lib_asm.s
+++ b/compiler_set/lib_asm.s
@@ -1811,3 +1811,19 @@ ans_direct:
 zero_div:
 	addi $r3, $r0, 0
 	return
+
+# display 命令を呼び直す
+# display y x char
+min_caml_display:
+	# 80 = 64 + 16
+	slli $r6, $r3, 6
+	slli $r7, $r3, 4
+	add $r6, $r6, $r7
+	add $r6, $r6, $r4
+	display $r6, $r5
+	return
+
+# readkbd の仮実装
+min_caml_readkbd:
+	inputb $r3
+	return

--- a/compiler_set/lib_asm.s
+++ b/compiler_set/lib_asm.s
@@ -1829,6 +1829,7 @@ min_caml_readkbd:
 	return
 
 min_caml_clear_display:
+	debug 8
 	addi $r3, $r0, 0
 	addi $r4, $r0, 2400
 clear_display_start:

--- a/compiler_set/lib_asm.s
+++ b/compiler_set/lib_asm.s
@@ -1827,3 +1827,14 @@ min_caml_display:
 min_caml_readkbd:
 	inputb $r3
 	return
+
+min_caml_clear_display:
+	addi $r3, $r0, 0
+	addi $r4, $r0, 2400
+clear_display_start:
+	display $r3, $r0
+	addi $r3, $r3, 1
+	blt $r3, $r4, clear_display_start
+	nop
+	nop
+	return

--- a/compiler_set/presen_soft/Makefile
+++ b/compiler_set/presen_soft/Makefile
@@ -1,0 +1,9 @@
+include ../test/Makefile.in
+
+# turn off binary(-b)
+OPTION := -inline 50
+# turn off test(-t)
+SIMULATOR := $(COMPILER_SET)/simulator/simulator
+
+test: main.bin
+	$(SIMULATOR) -f test.txt main.bin

--- a/compiler_set/presen_soft/main.ml
+++ b/compiler_set/presen_soft/main.ml
@@ -29,16 +29,6 @@ let rec read_line input  =
   (y, x, len)  in
 
 
-(* 画面のクリア *)
-let rec cls_sub2 y x =
-  if x < 0 then ()
-  else (*display y x 0;*) cls_sub2 y (x-1) in
-let rec cls_sub1 y =
-  if y < 0 then ()
-  else cls_sub2 y 79; cls_sub1 (y-1) in
-let rec cls _ = cls_sub1 23 in
-
-
 (* 文字列,行番号,列番号,文字数を受け取り,出力 *)
 let rec print_line_sub str y x n i =
   if i >= n then ()
@@ -56,7 +46,7 @@ let str = Array.create 80 0 in
 let rec main _ =
   let (y, x, len) = read_line str in
   if y = -2 then ()
-  else if y = -1 then (readkbd (); cls (); main ())
+  else if y = -1 then (readkbd (); clear_display (); main ())
   else (print_line str y x len; main ()) in
 
 main ()

--- a/compiler_set/presen_soft/main.ml
+++ b/compiler_set/presen_soft/main.ml
@@ -9,16 +9,17 @@
 (*NOMINCAML let rec readkbd _ = *)
 (*NOMINCAML   print_newline () in *)
 
+let column_max = 80 in
+let row_max = 30 in
+
 
 (* 1行読み取り配列に格納し,行番号、列番号、長さを返す.
    先頭の空白類文字は読み飛ばし *)
 let rec read_line_sub input n state =
   let c = input_char () in
-  if c = 10 then (input.(n) <- 0; n)
-  else if n >= 80 then (input.(n) <- 0; n)
+  if c = 10 or n >= column_max then (input.(n) <- 0; n)
   else if state = 0 then
-    if c < 33 then read_line_sub input n 0
-    else if c > 126 then read_line_sub input n 0
+    if c < 33 or c > 126 then read_line_sub input n 0
     else (input.(n) <- c; read_line_sub input (n+1) 1)
   else (input.(n) <- c; read_line_sub input (n+1) 1) in
 let rec read_line input  =
@@ -41,7 +42,7 @@ let rec print_line str y x n =
   print_line_sub str y x n 0 in
 
 
-let str = Array.create 80 0 in
+let str = Array.create column_max 0 in
 (* プログラムのメインループ.-1でページ切り替え,-2で終了 *)
 let rec main _ =
   let (y, x, len) = read_line str in

--- a/compiler_set/presen_soft/main.ml
+++ b/compiler_set/presen_soft/main.ml
@@ -1,22 +1,22 @@
 (* テスト用 *)
-let rec display y x c =
-  print_int y;
-  print_char 44;
-  print_int x;
-  print_char 44;
-  print_char c;
-  print_char 32 in
-let rec readkbd _ =
-  print_newline () in
+(*NOMINCAML let rec display y x c = *)
+(*NOMINCAML   print_int y; *)
+(*NOMINCAML   print_char 44; *)
+(*NOMINCAML   print_int x; *)
+(*NOMINCAML   print_char 44; *)
+(*NOMINCAML   print_char c; *)
+(*NOMINCAML   print_char 32 in *)
+(*NOMINCAML let rec readkbd _ = *)
+(*NOMINCAML   print_newline () in *)
 
 
 (* 1行読み取り配列に格納し,行番号、列番号、長さを返す.
    先頭の空白類文字は読み飛ばし *)
 let rec read_line_sub input n state =
   let c = input_char () in
-  if c = 10 then input.(n) <- 0; n
-  else if n >= 80 then input.(n) <- 0; n
-  else if state = 0 then 
+  if c = 10 then (input.(n) <- 0; n)
+  else if n >= 80 then (input.(n) <- 0; n)
+  else if state = 0 then
     if c < 33 then read_line_sub input n 0
     else if c > 126 then read_line_sub input n 0
     else (input.(n) <- c; read_line_sub input (n+1) 1)
@@ -24,7 +24,7 @@ let rec read_line_sub input n state =
 let rec read_line input  =
   let y = read_int () in
   if y < 0 then (y, 0, 0) else
-  let x = read_int () in  
+  let x = read_int () in
   let len = read_line_sub input 0 0 in
   (y, x, len)  in
 

--- a/compiler_set/presen_soft/test.txt
+++ b/compiler_set/presen_soft/test.txt
@@ -1,8 +1,7 @@
 10 24 test
 3 3 print
 5 6 jsidfjsoif
--1
+-1 0
 3 4 fdjsiof
 4 6 sjdif
 -2
-

--- a/compiler_set/simulator/Display.cpp
+++ b/compiler_set/simulator/Display.cpp
@@ -1,0 +1,39 @@
+#include "Display.h"
+
+#include <iostream>
+#include <cassert>
+
+using namespace std;
+
+Display::Display() {
+	for (int i = 0; i < COLUMNS*ROWS; i++) {
+		buffer[i] = 0;
+	}
+}
+
+void Display::set(uint32_t index, uint32_t ch) {
+	assert(index < DISPLAY_SIZE);
+	buffer[index] = ch & 0x7f;
+}
+
+void Display::preview() {
+	for (int x = 0; x < COLUMNS + 2; x++) {
+		cout << "-";
+	}
+	cout << endl;
+	for (int y = 0; y < ROWS; y++) {
+		cout << "|";
+		for (int x = 0; x < COLUMNS; x++) {
+			if (buffer[y*COLUMNS + x] > 32) {
+				cout << buffer[y*COLUMNS + x];
+			} else {
+				cout << " ";
+			}
+		}
+		cout << "|" << endl;
+	}
+	for (int x = 0; x < COLUMNS + 2; x++) {
+		cout << "-";
+	}
+	cout << endl;
+}

--- a/compiler_set/simulator/Display.h
+++ b/compiler_set/simulator/Display.h
@@ -1,0 +1,21 @@
+#ifndef _DISPLAY_H_
+#define _DISPLAY_H_
+
+#define COLUMNS 80
+#define ROWS 30
+#define DISPLAY_SIZE COLUMNS*ROWS
+
+#include <stdint.h>
+
+
+class Display {
+ private:
+	char buffer[DISPLAY_SIZE];
+
+ public:
+	Display();
+	void set(uint32_t index, uint32_t ch);
+	void preview();
+};
+
+#endif /* _DISPLAY_H_ */

--- a/compiler_set/simulator/Makefile
+++ b/compiler_set/simulator/Makefile
@@ -1,13 +1,14 @@
 include ../Makefile.in
 
-HEADER = ../include/common.h fpu.h logger.h simulator.h
+HEADER = ../include/common.h fpu.h logger.h simulator.h InputFile.h Display.h
 
 all:simulator
-simulator: simulator.o fpu.o logger.o InputFile.o
+simulator: simulator.o fpu.o logger.o InputFile.o Display.o
 simulator.o: $(HEADER)
 fpu.o: fpu.h
 logger.o: logger.h simulator.h
 InputFile.o: InputFile.h simulator.h
+Display.o: Display.h simulator.h
 
 clean:
 	rm *.o

--- a/compiler_set/simulator/simulator.cpp
+++ b/compiler_set/simulator/simulator.cpp
@@ -564,6 +564,9 @@ int simulate(simulation_options * opt)
 						printf("%d: %08x\n", j, ireg[j]);
 					}
 					break;
+				case 8:
+					display.preview();
+					break;
 				default:
 					break;
 				}

--- a/compiler_set/simulator/simulator.cpp
+++ b/compiler_set/simulator/simulator.cpp
@@ -3,6 +3,7 @@
 #include "simulator.h"
 #include "logger.h"
 #include "InputFile.h"
+#include "Display.h"
 
 #include <cmath>
 #include <cassert>
@@ -236,6 +237,8 @@ int simulate(simulation_options * opt)
 	int stack_pointer = 0;
 	char command[1024];
 	memset(internal_stack, 0, CALL_STACK_SIZE*sizeof(int));
+
+	Display display = Display();
 
 	if (load_program(opt) == 1)
 		return 1;
@@ -524,6 +527,9 @@ int simulate(simulation_options * opt)
 				}
 				logger.io((char)IRT);
 				break;
+			case DISPLAY:
+				display.set(IRS, IRT);
+				break;
 			case DEBUG:
 				if (opt->lib_test_mode) {
 					break;
@@ -573,6 +579,7 @@ int simulate(simulation_options * opt)
 	}
 	while (!isHalt(opcode, funct)); // haltが来たら終了
 
+	display.preview();
 	return 0;
 }
 

--- a/compiler_set/test/Makefile.in
+++ b/compiler_set/test/Makefile.in
@@ -48,4 +48,4 @@ ARTIFACTS=*.bin *.s
 	ocaml /tmp/`basename $*`.ml > $*.ocaml
 
 clean:
-	rm -f *.ocaml *.sim *.core $(ARTIFACTS)
+	rm -f *.ocaml *.sim *.core *.log $(ARTIFACTS)

--- a/compiler_set/test/asm/display.s
+++ b/compiler_set/test/asm/display.s
@@ -3,7 +3,7 @@
 	addi $r4, $r0, 2400
 	addi $r5, $r0, 65
 start:
-	blt $r4, $r3, end
+	ble $r4, $r3, end
 	nop
 	nop
 	display $r3, $r5

--- a/compiler_set/test/asm/display.s
+++ b/compiler_set/test/asm/display.s
@@ -1,8 +1,8 @@
 	nop
-start:
 	addi $r3, $r0, 0
 	addi $r4, $r0, 2400
 	addi $r5, $r0, 65
+start:
 	blt $r4, $r3, end
 	nop
 	nop

--- a/compiler_set/test/asm/display.s
+++ b/compiler_set/test/asm/display.s
@@ -1,0 +1,13 @@
+	nop
+start:
+	addi $r3, $r0, 0
+	addi $r4, $r0, 2400
+	addi $r5, $r0, 65
+	blt $r4, $r3, end
+	nop
+	nop
+	display $r3, $r5
+	addi $r3, $r3, 1
+	j start
+end:
+	halt


### PR DESCRIPTION
画面出力命令をアセンブラ、シミュレータ、ライブラリに追加し、シミュレータでプレゼンソフトのテストできるようにしました。

compiler_set/presen_soft にいって `make test` すると clear 直前の画面が描画されます。

@u-natsuki さん、変更点でおかしな部分がないか確認ねがいます(画面サイズ定数化のあたりなど)。
#20 でコメントした入力の扱い方の変更については別途おねがいします。
