### PR TITLE
遅延スロットの活用

### DIFF
--- a/compiler_set/compiler/Makefile
+++ b/compiler_set/compiler/Makefile
@@ -43,7 +43,7 @@ lambdaLift.ml closure.ml\
 flattenTuple.ml unfoldTuple.ml embedTuple.ml elimTuple.ml\
 asm.ml collectDanger.ml virtual.mli virtual.ml together.ml\
 simm.mli simm.ml graphColor.ml out.ml emit.ml\
-regAlloc.mli regAlloc.ml jumpElim.ml\
+regAlloc.mli regAlloc.ml jumpElim.ml delaySlotFilling.ml\
 main.mli main.ml
 
 include OCamlMakefile

--- a/compiler_set/compiler/closure.ml
+++ b/compiler_set/compiler/closure.ml
@@ -272,5 +272,4 @@ let f e =
   toplevel := [];
   globals := [];
   let e' = g M.empty S.empty M.empty true e in
-  List.iter (fun { gname = (Id.L(x), t) } -> Format.eprintf "%s@." x) !globals;
   Prog(!globals, List.rev !toplevel, e')

--- a/compiler_set/compiler/delaySlotFilling.ml
+++ b/compiler_set/compiler/delaySlotFilling.ml
@@ -1,0 +1,77 @@
+open Out
+
+(* 遅延スロットをうめるモジュール *)
+
+
+(* その命令で使われるレジスタ *)
+let used = function
+  | Label _ | SetL _ | Nop | Comment _ | FMvlo _ | FMvhi _ | J _ | Call _ | Return | Inputb _ | Halt -> S.empty
+  | AddI(_,x,_) | SubI(_,x,_) | XorI(_,x,_) | SllI(_,x,_) | SraI(_,x,_) | IMovF(_,x) | FMovI(_,x) | FInv(_,x) | FSqrt(_,x) | LdI(_,x,_) | FLdI(_,x,_) | Jr(x) | CallR(x) | Outputb(x) -> S.singleton x
+  | Add(_,x,y) | Sub(_,x,y) | Xor(_,x,y) | FAdd(_,x,y) | FSub(_,x,y) | FMul(_,x,y) | StI(x,y,_) | LdR(_,x,y) | FStI(x,y,_) | FLdR(_,x,y) | BEq(x,y,_,_) | BLT(x,y,_,_) | BLE(x,y,_,_) | FBEq(x,y,_,_) | FBLT(x,y,_,_) | FBLE(x,y,_,_) -> S.add x (S.singleton y)
+
+(* その命令のターゲットレジスタ *)
+let target = function
+  | SetL(x,_) | Add(x,_,_) | Sub(x,_,_) | Xor(x,_,_) | AddI(x,_,_) | SubI(x,_,_) | XorI(x,_,_) | FMvlo(x,_) | FMvhi(x,_) | SllI(x,_,_) | SraI(x,_,_) | IMovF(x,_) | FMovI(x,_) | FAdd(x,_,_) | FSub(x,_,_) | FMul(x,_,_) | FInv(x,_) | FSqrt(x,_) | LdI(x,_,_) | LdR(x,_,_) | FLdI(x,_,_) | FLdR(x,_,_) | Inputb(x) -> Some x
+  | _ -> None
+
+
+(* 遅延スロットに入れても大丈夫な命令を集める
+   readは分岐命令に影響するレジスタ。
+   writeは分岐命令までの間に上書きされるレジスタ *)
+let rec fill n read write l =
+  if n <= 0 then ([], l) else
+  match l with
+  | [] -> ([], [])
+  | (Comment _ as i)::xs -> let (ds, xs') = fill n read write xs in (ds, i::xs')
+  | (Label _ | BEq _ | BLT _ | BLE _ | FBEq _ | FBLT _ | FBLE _ | J _ | Jr _ | Call _ | CallR _ | Return | Halt)::_ -> ([], l) 
+  | i::xs ->
+      let u = used i in
+      match target i with
+      | Some x ->
+	  if not (S.mem x read) && S.is_empty (S.inter write u) then
+	    let (ds, xs') = fill (n-1) read write xs in
+            (i::ds, xs')
+	  else
+	    let (ds, xs') = fill n (S.union u read) (S.add x write) xs in
+	    (ds, i::xs')
+      | None ->
+	  if S.is_empty (S.inter write u) then
+	    let (ds, xs') = fill (n-1) read write xs in
+            (i::ds, xs')
+	  else
+	    let (ds, xs') = fill n (S.union u read) write xs in
+	    (ds, i::xs')
+
+
+
+(* 本体 *)
+let rec g ret = function
+  | [] -> ret
+  | BEq (x, y, l, ds)::xs ->
+      assert (List.length ds = 0);
+      let (ds, xs') = fill dsn (S.of_list [x;y]) S.empty xs in
+      g (BEq(x, y, l, List.rev ds)::ret) xs'
+  | BLT (x, y, l, ds)::xs ->
+      assert (List.length ds = 0);
+      let (ds, xs') = fill dsn (S.of_list [x;y]) S.empty xs in
+      g (BLT(x, y, l, List.rev ds)::ret) xs'
+  | BLE (x, y, l, ds)::xs ->
+      assert (List.length ds = 0);
+      let (ds, xs') = fill dsn (S.of_list [x;y]) S.empty xs in
+      g (BLE(x, y, l, List.rev ds)::ret) xs'
+  | FBEq (x, y, l, ds)::xs ->
+      assert (List.length ds = 0);
+      let (ds, xs') = fill dsn (S.of_list [x;y]) S.empty xs in
+      g (FBEq(x, y, l, List.rev ds)::ret) xs'
+  | FBLT (x, y, l, ds)::xs ->
+      assert (List.length ds = 0);
+      let (ds, xs') = fill dsn (S.of_list [x;y]) S.empty xs in
+      g (FBLT(x, y, l, List.rev ds)::ret) xs'
+  | FBLE (x, y, l, ds)::xs ->
+      assert (List.length ds = 0);
+      let (ds, xs') = fill dsn (S.of_list [x;y]) S.empty xs in
+      g (FBLE(x, y, l, List.rev ds)::ret) xs'
+  | x::xs -> g (x::ret) xs
+
+
+let f e = g [] (List.rev e)

--- a/compiler_set/compiler/delaySlotFilling.ml
+++ b/compiler_set/compiler/delaySlotFilling.ml
@@ -14,18 +14,6 @@ let target = function
   | SetL(x,_) | Add(x,_,_) | Sub(x,_,_) | Xor(x,_,_) | AddI(x,_,_) | SubI(x,_,_) | XorI(x,_,_) | FMvlo(x,_) | FMvhi(x,_) | SllI(x,_,_) | SraI(x,_,_) | IMovF(x,_) | FMovI(x,_) | FAdd(x,_,_) | FSub(x,_,_) | FMul(x,_,_) | FInv(x,_) | FSqrt(x,_) | LdI(x,_,_) | LdR(x,_,_) | FLdI(x,_,_) | FLdR(x,_,_) | Inputb(x) -> Some x
   | _ -> None
 
-(* 命令列の中にiと同じアドレスにアクセスする可能性のある命令があるか調べる *)
-let rec sa i = function
-  | (LdI _ | LdR _  | StI _ | FLdI _ | FStI _ | FLdR _ as x)::xs ->
-      same x y xs i || sa i xs
-  | x::xs -> sa i xs
-  | [] -> false
-(* 命令列の中にiと同じアドレスに書き込む可能性のある命令があるか調べる *)
-let rec sw i = function
-  | (StI _  | FStI _  _ as x)::xs ->
-      same x y xs i || sw i xs
-  | x::xs -> sw i xs
-  | [] -> false
 
 
 (* 遅延スロットに入れても大丈夫な命令を集める。

--- a/compiler_set/compiler/emit.ml
+++ b/compiler_set/compiler/emit.ml
@@ -147,68 +147,68 @@ and g' = function (* 各命令のアセンブリ生成 *)
 
   | Tail, IfEq(x, y, e1, e2) ->
       let b_taken = Id.genid "beq_taken" in
-      Out.print buf (Out.BEq(x, y, b_taken));
+      Out.print buf (Out.BEq(x, y, b_taken, []));
       g'_tail_if e1 e2 b_taken
   | Tail, IfLT(x, y, e1, e2) ->
       if e1 = Ans(Nop) && e2 = Ans(Nop) then () else
       if e2 = Ans(Nop) then g' (Tail, IfLE(y,x,e2,e1)) else
       let b_taken = Id.genid "blt_taken" in
-      Out.print buf (Out.BLT(x, y, b_taken));
+      Out.print buf (Out.BLT(x, y, b_taken, []));
       g'_tail_if e1 e2 b_taken
   | Tail, IfLE(x, y, e1, e2) ->
       if e1 = Ans(Nop) && e2 = Ans(Nop) then () else
       if e2 = Ans(Nop) then g' (Tail, IfLT(y,x,e2,e1)) else
       let b_taken = Id.genid "ble_taken" in
-      Out.print buf (Out.BLE(x, y, b_taken));
+      Out.print buf (Out.BLE(x, y, b_taken, []));
       g'_tail_if e1 e2 b_taken
   | Tail, IfFEq(x, y, e1, e2) ->
       let b_taken = Id.genid "fbeq_taken" in
-      Out.print buf (Out.FBEq(x, y, b_taken));
+      Out.print buf (Out.FBEq(x, y, b_taken, []));
       g'_tail_if e1 e2 b_taken
   | Tail, IfFLT(x, y, e1, e2) ->
       if e1 = Ans(Nop) && e2 = Ans(Nop) then () else
       if e2 = Ans(Nop) then g' (Tail, IfFLE(y,x,e2,e1)) else
       let b_taken = Id.genid "fblt_taken" in
-      Out.print buf (Out.FBLT(x, y, b_taken));
+      Out.print buf (Out.FBLT(x, y, b_taken, []));
       g'_tail_if e1 e2 b_taken
   | Tail, IfFLE(x, y, e1, e2) ->
       if e1 = Ans(Nop) && e2 = Ans(Nop) then () else
       if e2 = Ans(Nop) then g' (Tail, IfFLT(y,x,e2,e1)) else
       let b_taken = Id.genid "fble_taken" in
-      Out.print buf (Out.FBLE(x, y, b_taken));
+      Out.print buf (Out.FBLE(x, y, b_taken, []));
       g'_tail_if e1 e2 b_taken
 
   | NonTail(z), IfEq(x, y, e1, e2) ->
       let b_taken = Id.genid "beq_taken" in
-      Out.print buf (Out.BEq(x, y, b_taken));
+      Out.print buf (Out.BEq(x, y, b_taken, []));
       g'_non_tail_if (NonTail(z)) e1 e2 "beq" b_taken
   | NonTail(z), IfLT(x, y, e1, e2) ->
       if e1 = Ans(Nop) && e2 = Ans(Nop) then () else
       if e2 = Ans(Nop) then g' (NonTail(z), IfLE(y,x,e2,e1)) else
       let b_taken = Id.genid "blt_taken" in
-      Out.print buf (Out.BLT(x, y, b_taken));
+      Out.print buf (Out.BLT(x, y, b_taken, []));
       g'_non_tail_if (NonTail(z)) e1 e2 "blt" b_taken
   | NonTail(z), IfLE(x, y, e1, e2) ->
       if e1 = Ans(Nop) && e2 = Ans(Nop) then () else
       if e2 = Ans(Nop) then g' (NonTail(z), IfLT(y,x,e2,e1)) else
       let b_taken = Id.genid "ble_taken" in
-      Out.print buf (Out.BLE(x, y, b_taken));
+      Out.print buf (Out.BLE(x, y, b_taken, []));
       g'_non_tail_if (NonTail(z)) e1 e2 "ble" b_taken
   | NonTail(z), IfFEq(x, y, e1, e2) ->
       let b_taken = Id.genid "fbeq_taken" in
-      Out.print buf (Out.FBEq(x, y, b_taken));
+      Out.print buf (Out.FBEq(x, y, b_taken, []));
       g'_non_tail_if (NonTail(z)) e1 e2 "fbeq" b_taken
   | NonTail(z), IfFLT(x, y, e1, e2) ->
       if e1 = Ans(Nop) && e2 = Ans(Nop) then () else
       if e2 = Ans(Nop) then g' (NonTail(z), IfFLE(y,x,e2,e1)) else
       let b_taken = Id.genid "fblt_taken" in
-      Out.print buf (Out.FBLT(x, y, b_taken));
+      Out.print buf (Out.FBLT(x, y, b_taken, []));
       g'_non_tail_if (NonTail(z)) e1 e2 "fblt" b_taken
   | NonTail(z), IfFLE(x, y, e1, e2) ->
       if e1 = Ans(Nop) && e2 = Ans(Nop) then () else
       if e2 = Ans(Nop) then g' (NonTail(z), IfFLT(y,x,e2,e1)) else
       let b_taken = Id.genid "fble_taken" in
-      Out.print buf (Out.FBLE(x, y, b_taken));
+      Out.print buf (Out.FBLE(x, y, b_taken, []));
       g'_non_tail_if (NonTail(z)) e1 e2 "fble" b_taken
 
 (* 関数呼び出しの仮想命令の実装 *)
@@ -262,8 +262,6 @@ and g' = function (* 各命令のアセンブリ生成 *)
 
 and g'_tail_if e1 e2 b_taken =
   let stackset_back = !stackset in
-  Out.print buf Out.Nop;
-  Out.print buf Out.Nop;
   g (Tail, e2);
   Out.print buf (Out.Label b_taken);
   stackset := stackset_back;
@@ -271,8 +269,6 @@ and g'_tail_if e1 e2 b_taken =
 and g'_non_tail_if dest e1 e2 b b_taken =
   let b_cont = Id.genid (b ^ "_cont") in
   let stackset_back = !stackset in
-  Out.print buf Out.Nop;
-  Out.print buf Out.Nop;
   g (dest, e2);
   let stackset1 = !stackset in
   Out.print buf (Out.J b_cont);

--- a/compiler_set/compiler/jumpElim.ml
+++ b/compiler_set/compiler/jumpElim.ml
@@ -21,7 +21,7 @@ let rec find env m r = function
       (match r with
       | [] -> find (addre s t env) m r (Label t::xs)
       | x::y -> find (addre s t env) m y (x::Label t::xs))
-  | (J x | BEq(_,_,x) | BLT(_,_,x) | BLE(_,_,x) | FBEq(_,_,x) | FBLT(_,_,x) | FBLE(_,_,x))::(Label y)::xs when x = y ->
+  | (J x | BEq(_,_,x,_) | BLT(_,_,x,_) | BLE(_,_,x,_) | FBEq(_,_,x,_) | FBLT(_,_,x,_) | FBLE(_,_,x,_))::(Label y)::xs when x = y ->
       (match r with
       | [] -> find env m r (Label y::xs)
       | p::q -> find env m q (p::Label y::xs))
@@ -51,18 +51,18 @@ and rename env r = function
   | [] -> List.rev r
   | SetL(x, l)::xs when M.mem l env ->
       rename env r (SetL(x, M.find l env)::xs)
-  | BEq(x, y, l)::xs when M.mem l env ->
-      rename env r (BEq(x, y, M.find l env)::xs)
-  | BLT(x, y, l)::xs when M.mem l env ->
-      rename env r (BLT(x, y, M.find l env)::xs)
-  | BLE(x, y, l)::xs when M.mem l env ->
-      rename env r (BLE(x, y, M.find l env)::xs)
-  | FBEq(x, y, l)::xs when M.mem l env ->
-      rename env r (FBEq(x, y, M.find l env)::xs)
-  | FBLT(x, y, l)::xs when M.mem l env ->
-      rename env r (FBLT(x, y, M.find l env)::xs)
-  | FBLE(x, y, l)::xs when M.mem l env ->
-      rename env r (FBLE(x, y, M.find l env)::xs)
+  | BEq(x, y, l, ds)::xs when M.mem l env ->
+      rename env r (BEq(x, y, M.find l env, ds)::xs)
+  | BLT(x, y, l, ds)::xs when M.mem l env ->
+      rename env r (BLT(x, y, M.find l env, ds)::xs)
+  | BLE(x, y, l, ds)::xs when M.mem l env ->
+      rename env r (BLE(x, y, M.find l env, ds)::xs)
+  | FBEq(x, y, l, ds)::xs when M.mem l env ->
+      rename env r (FBEq(x, y, M.find l env, ds)::xs)
+  | FBLT(x, y, l, ds)::xs when M.mem l env ->
+      rename env r (FBLT(x, y, M.find l env, ds)::xs)
+  | FBLE(x, y, l, ds)::xs when M.mem l env ->
+      rename env r (FBLE(x, y, M.find l env, ds)::xs)
   | J l::xs when M.mem l env && M.find l env = !ret ->
       rename env (Return::r) xs 
   | J l::xs when M.mem l env ->
@@ -94,7 +94,7 @@ let rec h'' r s = function
   | x::xs -> h'' (x::r) s xs
 let rec h' s = function
   | [] -> s
-  | (SetL(_,l) | BEq(_,_,l) | BLE(_,_,l) | BLT(_,_,l) | FBEq(_,_,l) | FBLE(_,_,l)  | FBLT(_,_,l) | J l | Call l)::xs  -> h' (S.add l s) xs
+  | (SetL(_,l) | BEq(_,_,l,_) | BLE(_,_,l,_) | BLT(_,_,l,_) | FBEq(_,_,l,_) | FBLE(_,_,l,_)  | FBLT(_,_,l,_) | J l | Call l)::xs  -> h' (S.add l s) xs
   | _::xs -> h' s xs
 let h all = h'' [] (h' S.empty all) all
     

--- a/compiler_set/compiler/main.ml
+++ b/compiler_set/compiler/main.ml
@@ -41,6 +41,8 @@ let offet = Global.offet := false; Global.offet
 let offlt = ref false
 let offsi = ref false
 let offto = ref false
+let offje = ref false
+let offds = ref false
 
 let off flag f x = if !flag then x else f x
 
@@ -72,7 +74,8 @@ let lexbuf outchan l =
   Id.counter := 0;
   Typing.extenv := M.empty;
   Out.f outchan
-    (JumpElim.f
+    (off offds DelaySlotFilling.f
+    (off offje JumpElim.f
      (Emit.f
       (debas dbra (RegAlloc.f
        (debas dbto (off offto Together.f
@@ -90,7 +93,7 @@ let lexbuf outchan l =
 	            (debkn dbal (Alpha.f
 	             (debkn dbkn (KNormal.f
 	              (debsy dbty (Typing.f
-	               (debsy dbpa (parse_buf_exn l)))))))))))))))))))))))))))))))))))
+	               (debsy dbpa (parse_buf_exn l))))))))))))))))))))))))))))))))))))
 
 
 
@@ -144,7 +147,9 @@ let () =
    ("-offEmbedTuple", Arg.Set offet, "off: NO Embed Tuple");
    ("-offElimTuple", Arg.Set offlt, "off: NO Elim Tuple");
    ("-offSimm", Arg.Set offsi, "off: NO Simm");
-   ("-offTogether", Arg.Set offto, "off: NO Together");]
+   ("-offTogether", Arg.Set offto, "off: NO Together");
+   ("-offJumpElim", Arg.Set offje, "off: NO jump elim");
+   ("-offDelaySlotFilling", Arg.Set offds, "off: NO delay slot filling");]
     (fun s -> files := !files @ [s])
     ("Mitou Min-Caml Compiler (C) Eijiro Sumii\n" ^
         Printf.sprintf "usage: %s [-inline m] [-iter n] ...filenames without \".ml\"..." Sys.argv.(0));

--- a/compiler_set/simulator/simulator.cpp
+++ b/compiler_set/simulator/simulator.cpp
@@ -131,6 +131,8 @@ float asF(uint32_t r)
 #define DUMP_PC { printf("\tcurrent_pc: %d %s\n", pc, ROM[pc-1].getInst().c_str()); }
 #define DUMP_STACK { for (int i = 1; i < stack_pointer; i ++) {printf("\ts%2d: %5d %s\n", i, internal_stack[i]-1, ROM[internal_stack[i]-1].getInst().c_str());} }
 
+#define DELAY_SLOT 2 //遅延スロットの数
+
 //-----------------------------------------------------------------------------
 //
 // エンディアンの変換
@@ -245,6 +247,9 @@ int simulate(simulation_options * opt)
 
 	bool debug_flag = false;
 
+	int dspc[DELAY_SLOT+1] = {0};      //遅延分岐のキュー。毎週,pcは先頭の要素分だけ加算される。
+	int dshd = 0;                      //キューの先頭
+
 	// メインループ
 	do
 	{
@@ -264,6 +269,10 @@ int simulate(simulation_options * opt)
 		}
 		assert(FR < RAM_SIZE);
 		assert(HR < RAM_SIZE);
+
+		dshd = (dshd+1)%(DELAY_SLOT+1);
+		pc += dspc[dshd];
+		dspc[dshd] = 0;
 
 		assert(rom_addr(pc) >= 0);
 		inst = ROM[rom_addr(pc)].getCode();
@@ -336,6 +345,8 @@ int simulate(simulation_options * opt)
 
 		cnt++;
 		pc += ROM_ADDRESSING_UNIT;
+
+
 
 		if (debug_flag) {
 			DUMP_PC
@@ -434,22 +445,22 @@ int simulate(simulation_options * opt)
 
 				break;
 			case BEQ:
-				if (IRS == IRT) pc += IMM + (-1);
+			        if (IRS == IRT) dspc[dshd] = IMM + (-1) - DELAY_SLOT;
 				break;
 			case BLT:
-				if (IRS <  IRT) pc += IMM + (-1);
+			        if (IRS <  IRT) dspc[dshd] = IMM + (-1) - DELAY_SLOT;
 				break;
 			case BLE:
-				if (IRS <= IRT) pc += IMM + (-1);
+			        if (IRS <= IRT) dspc[dshd] = IMM + (-1) - DELAY_SLOT;
 				break;
 			case FBEQ:
-				if (asF(FRS) == asF(FRT)) pc += IMM + (-1);
+			        if (asF(FRS) == asF(FRT)) dspc[dshd] = IMM + (-1) - DELAY_SLOT;
 				break;
 			case FBLT:
-				if (asF(FRS) < asF(FRT)) pc += IMM + (-1);
+			        if (asF(FRS) <  asF(FRT)) dspc[dshd] = IMM + (-1) - DELAY_SLOT;
 				break;
 			case FBLE:
-				if (asF(FRS) <= asF(FRT)) pc += IMM + (-1);
+			        if (asF(FRS) <= asF(FRT)) dspc[dshd] = IMM + (-1) - DELAY_SLOT;
 				break;
 			case JR:
 			  	jump_logger.push_back(pc);

--- a/compiler_set/simulator/simulator.cpp
+++ b/compiler_set/simulator/simulator.cpp
@@ -132,6 +132,8 @@ float asF(uint32_t r)
 #define DUMP_PC { printf("\tcurrent_pc: %d %s\n", pc, ROM[pc-1].getInst().c_str()); }
 #define DUMP_STACK { for (int i = 1; i < stack_pointer; i ++) {printf("\ts%2d: %5d %s\n", i, internal_stack[i]-1, ROM[internal_stack[i]-1].getInst().c_str());} }
 
+#define DELAY_SLOT 2 //遅延スロットの数
+
 //-----------------------------------------------------------------------------
 //
 // エンディアンの変換
@@ -249,7 +251,12 @@ int simulate(simulation_options * opt)
 
 	bool debug_flag = false;
 
+
 	int end_marker = 0;
+
+	int dspc[DELAY_SLOT+1] = {0};      //遅延分岐のキュー。毎週,pcは先頭の要素分だけ加算される。
+	int dshd = 0;                      //キューの先頭
+
 
 	// メインループ
 	do
@@ -270,6 +277,10 @@ int simulate(simulation_options * opt)
 		}
 		assert(FR < RAM_SIZE);
 		assert(HR < RAM_SIZE);
+
+		dshd = (dshd+1)%(DELAY_SLOT+1);
+		pc += dspc[dshd];
+		dspc[dshd] = 0;
 
 		assert(rom_addr(pc) >= 0);
 		inst = ROM[rom_addr(pc)].getCode();
@@ -342,6 +353,8 @@ int simulate(simulation_options * opt)
 
 		cnt++;
 		pc += ROM_ADDRESSING_UNIT;
+
+
 
 		if (debug_flag) {
 			DUMP_PC
@@ -444,22 +457,22 @@ int simulate(simulation_options * opt)
 
 				break;
 			case BEQ:
-				if (IRS == IRT) pc += IMM + (-1);
+			        if (IRS == IRT) dspc[dshd] = IMM + (-1) - DELAY_SLOT;
 				break;
 			case BLT:
-				if (IRS <  IRT) pc += IMM + (-1);
+			        if (IRS <  IRT) dspc[dshd] = IMM + (-1) - DELAY_SLOT;
 				break;
 			case BLE:
-				if (IRS <= IRT) pc += IMM + (-1);
+			        if (IRS <= IRT) dspc[dshd] = IMM + (-1) - DELAY_SLOT;
 				break;
 			case FBEQ:
-				if (asF(FRS) == asF(FRT)) pc += IMM + (-1);
+			        if (asF(FRS) == asF(FRT)) dspc[dshd] = IMM + (-1) - DELAY_SLOT;
 				break;
 			case FBLT:
-				if (asF(FRS) < asF(FRT)) pc += IMM + (-1);
+			        if (asF(FRS) <  asF(FRT)) dspc[dshd] = IMM + (-1) - DELAY_SLOT;
 				break;
 			case FBLE:
-				if (asF(FRS) <= asF(FRT)) pc += IMM + (-1);
+			        if (asF(FRS) <= asF(FRT)) dspc[dshd] = IMM + (-1) - DELAY_SLOT;
 				break;
 			case JR:
 			  	jump_logger.push_back(pc);

--- a/compiler_set/test/Makefile.in
+++ b/compiler_set/test/Makefile.in
@@ -56,4 +56,4 @@ tmp = /tmp/$(basename $(1))_$(notdir $(HOME))
 	ocaml $(call tmp,$*).ml > $*.ocaml
 
 clean:
-	rm -f *.ocaml *.sim *.core *.log $(ARTIFACTS)
+	rm -f *.ocaml *.sim *.core *.log *.ppm $(ARTIFACTS)

--- a/compiler_set/test/min-rt/Makefile
+++ b/compiler_set/test/min-rt/Makefile
@@ -21,6 +21,7 @@ include ../Makefile.in
 	$(MIN_CAML) $(OPTION) $(call tmp,$*)
 	$(LINKER) $(LIB_ASM) $(call tmp,$*).s ${abspath $*.s}
 
+
 %.sim: %.bin
 	$(SIMULATOR) -f $(SLD_PATH) $*.bin > $*.sim
 

--- a/compiler_set/test/min-rt/Makefile
+++ b/compiler_set/test/min-rt/Makefile
@@ -32,6 +32,6 @@ include ../Makefile.in
 
 # use this with cserver
 # ./cserver -b -B 460800 sld/contest.sld contest_new.ppm
-#write: min-rt-new.bin
-#	$(CORE_RUNNER) $< -R
+write: min-rt-new.bin
+	$(CORE_RUNNER) $< -R
 

--- a/compiler_set/test/min-rt/Makefile
+++ b/compiler_set/test/min-rt/Makefile
@@ -21,14 +21,17 @@ include ../Makefile.in
 	$(MIN_CAML) $(OPTION) $(call tmp,$*)
 	$(LINKER) $(LIB_ASM) $(call tmp,$*).s ${abspath $*.s}
 
-
 %.sim: %.bin
 	$(SIMULATOR) -f $(SLD_PATH) $*.bin > $*.sim
+
+%.ppm: %.bin
+	$(SIMULATOR) -f $(SLD_PATH) $*.bin | tail -c +2 > output.ppm
 
 %.core: %.bin
 	$(CORE_RUNNER) $*.bin -i $(SLD_PATH) > $*.core
 
 # use this with cserver
 # ./cserver -b -B 460800 sld/contest.sld contest_new.ppm
-write: min-rt-new.bin
-	$(CORE_RUNNER) $< -R
+#write: min-rt-new.bin
+#	$(CORE_RUNNER) $< -R
+


### PR DESCRIPTION
シミュレータを遅延スロットに対応させ、コンパイラは可能なら遅延スロットをうめるようにしました。
シミュレータは、分岐命令がtakenだった場合、2命令後にpcを相対アドレス-2だけ加算します。
シミュレータを遅延スロットに対応させた直後の発行命令数は約22億4千万、
遅延スロットを活用するようにした後の発行命令数は約21億3千万です。
