### PR TITLE
bad_malloc バグを修正

### DIFF
--- a/compiler_set/simulator/BoundedBuffer.cpp
+++ b/compiler_set/simulator/BoundedBuffer.cpp
@@ -4,8 +4,6 @@
  */
 #include "BoundedBuffer.hpp"
 #include <ostream>
-#include <iostream>
-
 #include <vector>
 
 using namespace std;
@@ -31,7 +29,6 @@ BoundedBuffer::~BoundedBuffer() {
  * Add an element
  */
 void BoundedBuffer::add(int element) {
-	cout << "append" << element << endl;
 	_content[_pointer] = element;
 	_pointer = (_pointer + 1) % _size;
 	_valid_element_count = max(_valid_element_count, _pointer);

--- a/compiler_set/simulator/BoundedBuffer.cpp
+++ b/compiler_set/simulator/BoundedBuffer.cpp
@@ -12,11 +12,12 @@ using namespace std;
 /**
  * Default constructor
  */
-BoundedBuffer::BoundedBuffer(size_t size) {
+BoundedBuffer::BoundedBuffer(size_t size):
+	_size(size),
+	_pointer(0),
+	_valid_element_count(0)
+{
 	_content = vector<int>(size);
-	_size = size;
-	_pointer = 0;
-	_valid_element_count = 0;
 }
 
 /**

--- a/compiler_set/simulator/BoundedBuffer.cpp
+++ b/compiler_set/simulator/BoundedBuffer.cpp
@@ -1,0 +1,65 @@
+/**
+ * BoundedBuffer.cpp
+ *
+ */
+#include "BoundedBuffer.hpp"
+#include <ostream>
+#include <iostream>
+
+#include <vector>
+
+using namespace std;
+
+
+/**
+ * Default constructor
+ */
+BoundedBuffer::BoundedBuffer(size_t size) {
+	_content = vector<int>(size);
+	_size = size;
+	_pointer = 0;
+	_valid_element_count = 0;
+}
+
+/**
+ * Default destructor
+ */
+BoundedBuffer::~BoundedBuffer() {
+}
+
+/**
+ * Add an element
+ */
+void BoundedBuffer::add(int element) {
+	cout << "append" << element << endl;
+	_content[_pointer] = element;
+	_pointer = (_pointer + 1) % _size;
+	_valid_element_count = max(_valid_element_count, _pointer);
+}
+
+/**
+ * Get valid elements.  Ordered from old to new.
+ */
+vector<int> BoundedBuffer::valid_elements() const {
+	vector<int> ret;
+	for (int i = 0; i < _valid_element_count; i++) {
+		ret.push_back(_content[(i + _pointer - _valid_element_count + _size) % _size]);
+	}
+	return ret;
+}
+
+/**
+ * stream output operator
+ */
+std::ostream& operator<<(std::ostream& lhs, const BoundedBuffer& rhs) {
+	vector<int> elements = rhs.valid_elements();
+	vector<int>::iterator it = elements.begin();
+	lhs << "BoundedBuffer{";
+	while (it < elements.end()-1) {
+		lhs << (*it) << ", ";
+		it++;
+	}
+	lhs << (*it);
+	lhs << "}";
+	return lhs;
+}

--- a/compiler_set/simulator/BoundedBuffer.hpp
+++ b/compiler_set/simulator/BoundedBuffer.hpp
@@ -8,7 +8,7 @@ using namespace std;
 
 class BoundedBuffer {
 	vector<int> _content;
-	size_t _size;
+	const size_t _size;
 	int _pointer;
 	int _valid_element_count;
 public:

--- a/compiler_set/simulator/BoundedBuffer.hpp
+++ b/compiler_set/simulator/BoundedBuffer.hpp
@@ -1,0 +1,26 @@
+#ifndef STD_BOUNDEDBUFFER_H_
+#define STD_BOUNDEDBUFFER_H_
+
+#include <iosfwd>
+#include <vector>
+
+using namespace std;
+
+class BoundedBuffer {
+	vector<int> _content;
+	size_t _size;
+	int _pointer;
+	int _valid_element_count;
+public:
+	/// Default constructor
+	BoundedBuffer(size_t size);
+	/// Destructor
+	~BoundedBuffer();
+	void add(int element);
+	vector<int> valid_elements() const;
+};
+
+/// stream output operator
+std::ostream& operator<<(std::ostream& lhs, const BoundedBuffer& rhs);
+
+#endif /* STD_BOUNDEDBUFFER_H_ */

--- a/compiler_set/simulator/Makefile
+++ b/compiler_set/simulator/Makefile
@@ -3,13 +3,14 @@ include ../Makefile.in
 HEADER = ../include/common.h fpu.h logger.h simulator.h InputFile.h Display.h
 
 all:simulator
-simulator: simulator.o fpu.o logger.o InputFile.o Display.o SDCard.o
+simulator: simulator.o fpu.o logger.o InputFile.o Display.o SDCard.o BoundedBuffer.o
 simulator.o: $(HEADER)
 fpu.o: fpu.h
 logger.o: logger.h simulator.h
 InputFile.o: InputFile.h simulator.h
 Display.o: Display.h simulator.h
 SDCard.o: SDCard.h simulator.h
+BoundedBuffer.o: BoundedBuffer.hpp
 
 clean:
 	rm *.o


### PR DESCRIPTION
bad_malloc の原因はジャンプのたびに push される jump_logger で、単純にメモリをくいつぶしていた可能性が高い。
後から見る上限回数は決まっているので、bounded buffer を導入した。

@u-natsuki さん。問題なく使えるかだけ確認おねがいします。
