### PR TITLE
コンパイラの最適化

### DIFF
--- a/compiler_set/Makefile
+++ b/compiler_set/Makefile
@@ -84,4 +84,4 @@ lor-clean:
 	cd linker; $(LINKER) ../$(LIB_ASM) ../__tmp__.s ${abspath $*.s}
 
 min-rt-test:
-	cd test/min-rt; make BIN=-x min-rt-new-bin.test; cd ../..
+	cd test/min-rt; rm -f min-rt-new-bin.bin; make BIN=-x min-rt-new-bin.test; cd ../..

--- a/compiler_set/compiler/aliasAnalysis.ml
+++ b/compiler_set/compiler/aliasAnalysis.ml
@@ -215,11 +215,11 @@ let f e =
   analyse x M.empty M.empty e;
   let gr =
     M.fold
-      (fun x (t,p,q) gr -> match t with
-      | Type.Array _ ->
+      (fun x (t,p,q) gr ->
+	if earray t then
 	  let q' = M.fold (fun x _ s -> S.add x s) q S.empty in
 	  M.add x (t,p,q') gr
-      | _ -> gr)
+        else gr)
       !graph
       M.empty in
   let fil p = S.filter (fun x -> M.mem x gr) p in

--- a/compiler_set/compiler/cse.ml
+++ b/compiler_set/compiler/cse.ml
@@ -2,21 +2,35 @@ open ANormal
 
 (* 共通部分式除去を行うモジュール *)
 
-let qlen = 10
+(*let qlen = 10 
 
-let add x l = if List.mem_assoc (fst x) l then l else x::l
+let dummy = (Var(Id.genid ""), "") *)
 
-let dummy = Var(Id.genid "")
+type environ = {
+    precious : (exp * Id.t) list;
+    cheap : (exp * Id.t) list;
+    noeffect : S.t;
+    tuple : (Id.t list) M.t;
+  }
 
 (* envを操作する関数群 *)
-let addq x l =
-  let l' = add x l in if List.length l' > qlen then List.tl l' else l'
-let push l = addq (dummy, "%g0") l
-let rec pushn n l = if n<=0 then l else pushn (n-1) (push l)
+let add_precious exp x env =
+  { env with precious = (exp,x)::env.precious }
+let rec take n = function
+  | [] -> []
+  | x::xs -> if n <= 0 then [] else x::take (n-1) xs 
+let add_cheap exp x env =
+  { env with cheap = (exp,x)::env.cheap }
+(*let rec pushn n env = env
+  let rec f m l = if m <= 0 || List.mem dummy l then l else f (m-1) (dummy::l) in
+  { env with cheap = take' qlen (f (min n qlen) (env.cheap)) } *)
+let add_tuple x ys env =
+  { env with tuple = M.add x ys env.tuple }
+let make_empty e env =
+  let fvs = fv e in
+  { env with precious = List.filter (fun (_,x) -> S.mem x fvs) env.precious;
+             cheap = List.filter (fun (_,x) -> S.mem x fvs) env.cheap }
 
-
-(* 部分式をインデックスに変数を引く関数 *)
-let rec find x env = try Var(List.assoc x env) with Not_found -> x
 
 (* 式の中に関数呼び出しがあるか判定 *)
 let rec ecall = function
@@ -29,39 +43,79 @@ and ecall' = function
   | App _ | ExtFunApp _ -> true
   | _ -> false
 
+
+let rec effect env = function (* 副作用(Get含む)の有無 *)
+  | Let(_, exp, e) -> effect' env exp || effect env e
+  | LetRec({ name = (x,_); args = _; body = e1 }, e) ->
+      let env' = 
+	let env' = S.add x env in
+	if effect env' e1 then env else env' in
+      effect env' e
+  | LetTuple(_, _, e) | LetList(_,_,e) -> effect env e
+  | Ans(exp) -> effect' env exp
+and effect' env = function
+  | IfEq(_, _, e1, e2) | IfLE(_, _, e1, e2) | IfLT(_, _, e1, e2) | IfNil(_,e1,e2)-> effect env e1 || effect env e2
+  (* 副作用の無いライブラリ関数 *)
+  | ExtFunApp (("create_array" | "create_float_array" | "create_tuple_array" | "floor" | "ceil" | "float_of_int" | "int_of_float" | "truncate" | "not" | "xor" | "sqrt"  | "atan" | "tan" | "sin" | "cos" | "log" | "exp"  | "land" | "sinh" | "cosh" | "mul" | "div_binary_search" | "div" ), _) -> false
+  | App (x, _) when S.mem x env -> false
+  | App _ | Put _ | Get _ | ExtFunApp _ -> true
+  | _ -> false
+
+
 (* 共通部分式除去を行う関数 *)
-let rec g env env2 env3 = function
+let rec g env = function
   | Let((x,_) as xt, exp, e) ->
-      let exp' = find (g' env env2 env3 exp) (env@env3) in
+      let exp' = g' env exp in
       (match exp' with
-      | Unit | Var _ | Get _ | Put _ | Tuple _ | ExtArray _ | Nil -> 
-	  Let(xt, exp', g env env2 (push env3) e)
+      | Unit | Var _ | Get _ | Put _ | ExtArray _ | Nil -> 
+	  Let(xt, exp', g env e)
       | Int i when -0x8000 <= i && i <= 0x7FFF ->
-	  Let(xt, exp', g env env2 (addq (exp', x) env3) e)
-      | App(y, _) ->
-	  if S.mem y env2 then Let(xt, exp', g [] env2 [] e)
-	  else Let(xt, exp', g [(exp', x)] env2 [] e)
-      | ExtFunApp _ -> Let(xt, exp', g [] env2 [] e)
+	  Let(xt, exp', g (add_cheap exp' x env) e)
+      | App(y, _) when S.mem y env.noeffect  ->
+	  Let(xt, exp', g (add_precious exp' x (make_empty e env)) e)
+      | ExtFunApp(("print_char"|"input_char"|"read_char"),_) ->
+	  Let(xt, exp', g env e)
+      | ExtFunApp(("xor"|"sqrt"|"not"),_) ->
+	  Let(xt, exp', g (add_precious exp' x env) e)
+      | ExtFunApp (("floor" | "ceil" | "float_of_int" | "int_of_float" | "truncate" | "atan" | "tan" | "sin" | "cos" | "log" | "exp"  | "land" | "sinh" | "cosh" | "mul" | "div_binary_search" | "div" ), _) ->
+	  Let(xt, exp', g (add_precious exp' x (make_empty e env)) e)
+      | App _ | ExtFunApp _ -> Let(xt, exp', g (make_empty e env) e)
       | _ ->
-	  let env3' = if ecall' exp' then [] else pushn (size' exp') env3 in
-	  Let(xt, exp', g (add (exp',x) env) env2 (pushn (size' exp') env3) e))
+	  let env' =
+	    let env' = if ecall' exp' then make_empty e env else env in
+	    if effect' env'.noeffect exp' then env'
+	    else add_precious exp' x env' in
+	  Let(xt, exp', g (add_precious exp' x env') e))
   | LetRec({ name = (x,_) as xt; args = yts; body = e1 }, e2) ->
-      let env2' =
-	let env2' = S.add x env2 in
-	if Elim.effect env2' e1 then env2 else env2' in
-      LetRec({ name = xt; args = yts; body = g [] env2' env3 e1 }, g env env2' (push env3) e2)
+      let env' =
+	let eff = S.add x env.noeffect in
+	if effect eff e1 then env else { env with noeffect = eff } in
+      LetRec({ name = xt; args = yts; body = g (make_empty e1 env') e1 }, g env' e2)
   | LetTuple(l, y, e) ->
-      LetTuple(l, y, g env env2 (pushn (List.length l) env3) e)
-  | LetList((x,_) as xt, y, e) ->
-      LetList(xt, y, g env env2 (pushn (List.length (Syntax.matcher_variables x)) env3) e)
-  | Ans(exp) -> Ans(g' env env2 env3 exp)
-and g' env env2 env3 = function
-  | IfEq(x, y, e1, e2) -> IfEq(x, y, g env env2 env3 e1, g env env2 env3 e2)
-  | IfLE(x, y, e1, e2) -> IfLE(x, y, g env env2 env3 e1, g env env2 env3 e2)
-  | IfLT(x, y, e1, e2) -> IfLT(x, y, g env env2 env3 e1, g env env2 env3 e2)
-  | IfNil(x, e1, e2) -> IfNil(x, g env env2 env3 e1, g env env2 env3 e2)
-  | e -> e
+      if M.mem y env.tuple then
+	let l' = M.find y env.tuple in
+	List.fold_left2
+	  (fun e xt x' -> Let(xt,Var(x'),e))
+	  (g env e)
+	  l
+	  l'
+      else LetTuple(l, y, g (add_tuple y (List.map fst l) env) e)
+  | LetList(xt, y, e) ->
+      LetList(xt, y, g env e)
+  | Ans(exp) -> Ans(g' env exp)
+and g' env exp =
+  let exp' = match exp with
+  | IfEq(x, y, e1, e2) -> IfEq(x, y, g env e1, g env e2)
+  | IfLE(x, y, e1, e2) -> IfLE(x, y, g env e1, g env e2)
+  | IfLT(x, y, e1, e2) -> IfLT(x, y, g env e1, g env e2)
+  | IfNil(x, e1, e2) -> IfNil(x, g env e1, g env e2)
+  | exp -> exp in
+  try Var(List.assoc exp' (env.precious@env.cheap))
+  with Not_found -> exp'
 	
 
 let f e = Format.eprintf "eliminating common subexpressions...@.";
-          g [] S.empty [] e
+          g { precious = []; cheap = []; noeffect = S.empty; tuple = M.empty } e
+
+
+

--- a/compiler_set/compiler/elim.ml
+++ b/compiler_set/compiler/elim.ml
@@ -3,7 +3,12 @@ open ANormal
 
 let rec effect env = function (* 副作用の有無 *)
   | Let(_, exp, e) -> effect' env exp || effect env e
-  | LetRec(_, e) | LetTuple(_, _, e) | LetList(_,_,e) -> effect env e
+  | LetRec({ name = (x,_); args = _; body = e1 }, e) ->
+      let env' = 
+	let env' = S.add x env in
+	if effect env' e1 then env else env' in
+      effect env' e
+  | LetTuple(_, _, e) | LetList(_,_,e) -> effect env e
   | Ans(exp) -> effect' env exp
 and effect' env = function
   | IfEq(_, _, e1, e2) | IfLE(_, _, e1, e2) | IfLT(_, _, e1, e2) | IfNil(_,e1,e2)-> effect env e1 || effect env e2

--- a/compiler_set/compiler/elimGetPut.ml
+++ b/compiler_set/compiler/elimGetPut.ml
@@ -173,7 +173,11 @@ and g' dest env mem const = function
 	    (exp,mem'))
   | ExtFunApp(("create_array"|"create_float_array"|"create_tuple_array"),_::x::_) as exp ->
       (exp, ovwr dest (A(M'.empty, x)) mem)
-    | App _ | ExtFunApp _ as exp ->
+  | ExtFunApp(("xor"|"sqrt"|"not"|"print_char"|"input_char"|"read_char"),_) as exp ->      
+      (* 後でコンパイラで展開される外部関数。
+	 退避不要なのでここをまたぐ変数はスタックに置かれない *)
+      (exp, mem)
+  | App _ | ExtFunApp _ as exp ->
       (* メモリの状態を空っぽに *)
       (exp, M.map (fun (y,_) -> (y,unknown)) mem)
   | exp -> (exp, mem)

--- a/compiler_set/compiler/graphColor.ml
+++ b/compiler_set/compiler/graphColor.ml
@@ -145,7 +145,7 @@ let rem x g =
   M.map
     (fun (p,q,r) ->
       if List.mem x p then
-	let sc = if S.mem x r then 12 else 0 in
+	let sc = if S.mem x r then 10 else 0 in
 	(List.filter (fun y -> x <> y) p, q+1+sc, r)
       else (p,q,r))
     (M.remove x g)

--- a/compiler_set/compiler/main.ml
+++ b/compiler_set/compiler/main.ml
@@ -51,9 +51,8 @@ let off2 flag f x = if flag then x else f x
 (* 最適化処理をくりかえす *)
 let rec iter n e = 
   Format.eprintf "iteration %d@." n;
-  let f e = if n = 997 then (print_endline (Show.show<ANormal.t> e); e) else e in
   if n = 0 then e else
-  let e' =  off offel Elim.f (off offte IfThenElse.f (off offcf ConstFold.f (off offin Inline.f (off2 (!offaa || (n mod 2 <> 0)) AliasAnalysis.f ( (off offbe Beta.f (off offcs Cse.f e))))))) in
+  let e' =  off offel Elim.f (off offte IfThenElse.f (off offcf ConstFold.f (off offin (Inline.f (!limit-n)) (off2 (!offaa || (n mod 2 <> 0)) AliasAnalysis.f ( (off offbe Beta.f (off offcs Cse.f e))))))) in
   Format.eprintf "@.";
   if Beta.same M.empty e e' then e else
   iter (n - 1) e'
@@ -143,7 +142,7 @@ let () =
    ("-offBeta", Arg.Set offbe, "off: NO beta");
    ("-offInline", Arg.Set offin, "off: NO Inline");
    ("-offConstFold", Arg.Set offcf, "off: NO ConstFold");
-   ("-offIfThenElse", Arg.Set offel, "off: NO if then else");
+   ("-offIfThenElse", Arg.Set offte, "off: NO if then else");
    ("-offElim", Arg.Set offel, "off: NO Elim");
    ("-offAliasAnalysis", Arg.Set offaa, "off: NO Alias Analysis");
    ("-offLambdaLift", Arg.Set offll, "off: NO LambdaLift");

--- a/compiler_set/compiler/main.ml
+++ b/compiler_set/compiler/main.ml
@@ -35,7 +35,7 @@ let offin = ref false
 let offcf = ref false
 let offte = ref false
 let offel = ref false
-let offaa = ref false  (* バグがある様で、trueにするとバグる *)
+let offaa = ref false  
 let offll = ref false
 let offut = ref false
 let offet = Global.offet := false; Global.offet
@@ -53,7 +53,7 @@ let rec iter n e =
   Format.eprintf "iteration %d@." n;
   let f e = if n = 997 then (print_endline (Show.show<ANormal.t> e); e) else e in
   if n = 0 then e else
-  let e' =  off offel Elim.f (off offte IfThenElse.f (off offcf ConstFold.f (off offin Inline.f (off2 (!offaa || (n mod 3 <> 1)) AliasAnalysis.f ( (off offbe Beta.f (off offcs Cse.f e))))))) in
+  let e' =  off offel Elim.f (off offte IfThenElse.f (off offcf ConstFold.f (off offin Inline.f (off2 (!offaa || (n mod 2 <> 0)) AliasAnalysis.f ( (off offbe Beta.f (off offcs Cse.f e))))))) in
   Format.eprintf "@.";
   if Beta.same M.empty e e' then e else
   iter (n - 1) e'

--- a/compiler_set/compiler/main.ml
+++ b/compiler_set/compiler/main.ml
@@ -35,7 +35,7 @@ let offin = ref false
 let offcf = ref false
 let offte = ref false
 let offel = ref false
-let offaa = ref true  (* バグがある様で、trueにするとバグる *)
+let offaa = ref false  (* バグがある様で、trueにするとバグる *)
 let offll = ref false
 let offut = ref false
 let offet = Global.offet := false; Global.offet

--- a/compiler_set/simulator/simulator.cpp
+++ b/compiler_set/simulator/simulator.cpp
@@ -514,6 +514,9 @@ int simulate(simulation_options * opt)
 				pc = IRS;
 				break;
 			case RETURN:
+				if (opt->disable_end_marker && stack_pointer == 0) {
+					goto end_simulation;
+				}
 				assert(stack_pointer > 0);
 				pc = internal_stack[stack_pointer--];
 				break;

--- a/compiler_set/test/Makefile.in
+++ b/compiler_set/test/Makefile.in
@@ -8,7 +8,7 @@ LIB_ML = $(COMPILER_SET)/lib_ml.ml
 LIB_ASM = $(COMPILER_SET)/lib_asm.s
 
 MIN_CAML=BISECT_FILE=$(COMPILER_SET)/compiler/coverage $(COMPILER_SET)/compiler/min-caml
-OPTION= -b -inline 150 
+OPTION= -b -inline 600 
 
 LINKER=groovy $(COMPILER_SET)/linker/linker.groovy
 

--- a/compiler_set/test/Makefile.in
+++ b/compiler_set/test/Makefile.in
@@ -8,7 +8,7 @@ LIB_ML = $(COMPILER_SET)/lib_ml.ml
 LIB_ASM = $(COMPILER_SET)/lib_asm.s
 
 MIN_CAML=BISECT_FILE=$(COMPILER_SET)/compiler/coverage $(COMPILER_SET)/compiler/min-caml
-OPTION= -b -inline 600 
+OPTION= -b -inline 600
 
 LINKER=groovy $(COMPILER_SET)/linker/linker.groovy
 

--- a/compiler_set/test/min-rt/Makefile
+++ b/compiler_set/test/min-rt/Makefile
@@ -35,3 +35,4 @@ include ../Makefile.in
 # ./cserver -b -B 460800 sld/contest.sld contest_new.ppm
 write: min-rt-new-bin.bin
 	$(CORE_RUNNER) $< -R
+

--- a/compiler_set/test/min-rt/Makefile
+++ b/compiler_set/test/min-rt/Makefile
@@ -11,6 +11,8 @@ targets:
 
 include ../Makefile.in
 
+OPTION= -b -inline 600 -offEmbedTuple -offUnfoldTuple
+
 # It should not depend on %.sim, because this is not updated after sim is updated.
 %.ans:
 	make $*.sim
@@ -23,7 +25,7 @@ include ../Makefile.in
 
 
 %.sim: %.bin
-	$(SIMULATOR) $(BIN) -f $(SLD_PATH) $*.bin > $*.sim
+	$(SIMULATOR) $(BIN) -f $(SLD_PATH) -x $*.bin > $*.sim
 
 %.ppm: %.bin
 	$(SIMULATOR) $(BIN) -f $(SLD_PATH) $*.bin | tail -c +2 > output.ppm

--- a/compiler_set/test/min-rt/Makefile
+++ b/compiler_set/test/min-rt/Makefile
@@ -27,8 +27,8 @@ OPTION= -b -inline 600 -offEmbedTuple -offUnfoldTuple
 %.sim: %.bin
 	$(SIMULATOR) $(BIN) -f $(SLD_PATH) -x $*.bin > $*.sim
 
-%.ppm: %.bin
-	$(SIMULATOR) $(BIN) -f $(SLD_PATH) $*.bin | tail -c +2 > output.ppm
+%.ppm: %.sim
+	tail -c +2 $< > $@
 
 %.core: %.bin
 	$(CORE_RUNNER) $*.bin -i $(SLD_PATH) > $*.core


### PR DESCRIPTION
インライン展開の改良を行いました。
発行命令数は16億4千万くらいです。
コンパイル時に-offEmbedTuple, -offUnfoldTuple オプションをつけてタプルの展開を止めさせると、
使うヒープが増える代わりにさらに1千万命令くらい減ります。
